### PR TITLE
updated submodule paths so ssh keys are not needed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "src/opusfile"]
 	path = src/opusfile
-	url = git@github.com:xiph/opusfile.git
+	url = https://github.com/xiph/opusfile
 
 [submodule "src/opus"]
 	path = src/opus
-	url = git@github.com:xiph/opus.git
+	url = https://github.com/xiph/opus
 
 [submodule "src/ogg"]
 	path = src/ogg
-	url = git@github.com:xiph/ogg.git
+	url = https://github.com/xiph/ogg


### PR DESCRIPTION
The submodule URL format requires ssh authentication for the "git submodule update --init" to work. I updated the URL format to use https, now even users who are not logged in can run the build.